### PR TITLE
fix: dont trigger errors on vscode json files

### DIFF
--- a/src/ast/index.ts
+++ b/src/ast/index.ts
@@ -8,7 +8,7 @@ import { parseJson, JsonNode } from './json';
 import { parseYaml, findYamlNodeAtOffset, YamlNode } from './yaml';
 import { ParserOptions } from '../parser-options';
 
-function parse(text: string, languageId: string, options: ParserOptions): [Node, any[]] {
+function parse(text: string, languageId: string, options: ParserOptions): [Node, {message: string, offset: number}[]] {
   return languageId === 'yaml' ? parseYaml(text, options.get().yaml.schema) : parseJson(text);
 }
 

--- a/src/ast/json.ts
+++ b/src/ast/json.ts
@@ -7,9 +7,11 @@ import * as json from 'jsonc-parser';
 import { Node } from './types';
 import { parseJsonPointer, joinJsonPointer } from '../pointer';
 
-export function parseJson(text: string): [JsonNode, any[]] {
-  const parseErrors = [];
-  const node = new JsonNode(json.parseTree(text, parseErrors));
+export function parseJson(text: string): [JsonNode, {message: string, offset: number}[]] {
+  const parseErrors: json.ParseError[] = [];
+  const node = new JsonNode(
+    json.parseTree(text, parseErrors, {allowTrailingComma: true})
+  )
   const normalizedErrors = parseErrors.map((error) => ({
     message: json.printParseErrorCode(error.error),
     offset: error.offset,

--- a/src/ast/yaml.ts
+++ b/src/ast/yaml.ts
@@ -8,7 +8,7 @@ import { Schema } from 'js-yaml';
 import { Node } from './types';
 import { parseJsonPointer, joinJsonPointer } from '../pointer';
 
-export function parseYaml(text: string, schema: Schema): [YamlNode, any[]] {
+export function parseYaml(text: string, schema: Schema): [YamlNode, {message: string, offset: number}[]] {
   const documents = [];
   yaml.loadAll(
     text,

--- a/src/audit/commands.ts
+++ b/src/audit/commands.ts
@@ -163,7 +163,7 @@ async function performAudit(context, textEditor: vscode.TextEditor, apiToken, pr
   }
 }
 
-function parseDocument(document) {
+function parseDocument(document: vscode.TextDocument) {
   const [root, errors] = parse(document.getText(), document.languageId, parserOptions);
   // FIXME ignore errors for now, the file has been bundled so
   // errors here are mostly warnings

--- a/src/bundler-parsers.ts
+++ b/src/bundler-parsers.ts
@@ -5,11 +5,11 @@ import * as vscode from 'vscode';
 import { ParserOptions } from './parser-options';
 
 const parseJson = (text: string) => {
-  const errors = [];
-  const parsed = json.parse(text, errors);
+  const errors: json.ParseError[] = [];
+  const parsed = json.parse(text, errors, {allowTrailingComma: true});
   if (errors.length > 0) {
     const message = errors
-      .map((error: json.ParseError) => `${json.printParseErrorCode(error.error)} at offset ${error.offset}`)
+      .map((error) => `${json.printParseErrorCode(error.error)} at offset ${error.offset}`)
       .join(', ');
     throw new Error(`Failed to parse JSON: ${message}`);
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,10 +12,11 @@ export function parseDocument(document: vscode.TextDocument): [OpenApiVersion, N
 
   const [node, errors] = parse(document.getText(), document.languageId, parserOptions);
   const version = getOpenApiVersion(node);
-  const messages = errors.map((error) => {
+  const messages = errors.map((error): vscode.Diagnostic => {
     const position = document.positionAt(error.offset);
     const line = document.lineAt(position);
     return {
+      source: 'vscode-openapi',
       code: '',
       severity: vscode.DiagnosticSeverity.Error,
       message: error.message,


### PR DESCRIPTION
fixes #81 

By [default, `jsonc-parser` doesn't allow trailing commas](https://github.com/microsoft/node-jsonc-parser/blob/7505449/src/impl/parser.ts#L24)

I also took the liberty of improving the error message shown to the user to show that it's from this extension [(the change in src/util)](https://github.com/42Crunch/vscode-openapi/compare/master...forivall:fix/jsonc-trailing-commas?expand=1&ts=2#diff-3294a832ea2276e554177e0b3007cc2d401c082912c7fbde49fa09141bf1aed1), since i had to go through extensions and disable them to figure out that it was this extension.