### PR TITLE
fix: Autocompletion for single quote in yaml file

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -51,7 +51,6 @@ export class CompletionItemProvider implements vscode.CompletionItemProvider {
     token: vscode.CancellationToken,
     context: vscode.CompletionContext
   ) {
-	
     if (!this.root) {
       return;
     }

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -51,6 +51,7 @@ export class CompletionItemProvider implements vscode.CompletionItemProvider {
     token: vscode.CancellationToken,
     context: vscode.CompletionContext
   ) {
+	
     if (!this.root) {
       return;
     }
@@ -96,16 +97,16 @@ export class CompletionItemProvider implements vscode.CompletionItemProvider {
 
     const target = findTarget(this.root, this.version, node);
     const targetNode = target && searchRoot.find(target);
-    const qouteChar =
+    const quoteChar =
       line.charAt(position.character) == '"' || line.charAt(position.character) == "'"
         ? line.charAt(position.character)
         : '"';
     if (targetNode) {
       // don't include trailing quote when completing YAML and
       // there are already quotes in line
-      let trailingQuote = qouteChar;
+      let trailingQuote = quoteChar;
       let leadingSpace = " ";
-      if (line.charAt(position.character) == qouteChar) {
+      if (line.charAt(position.character) == quoteChar) {
         leadingSpace = "";
         if (document.languageId === "yaml") {
           trailingQuote = "";
@@ -114,7 +115,7 @@ export class CompletionItemProvider implements vscode.CompletionItemProvider {
       const completions = targetNode.getChildren().map((child) => {
         const key = child.getKey();
         return new vscode.CompletionItem(
-          `${leadingSpace}${qouteChar}${fileRef}#${target}/${key}${trailingQuote}`
+          `${leadingSpace}${quoteChar}${fileRef}#${target}/${key}${trailingQuote}`
         );
       });
       return completions;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,11 @@ export function activate(context: vscode.ExtensionContext) {
 
   const completionProvider = new CompletionItemProvider(context, cache);
   for (const selector of Object.values(selectors)) {
-    vscode.languages.registerCompletionItemProvider(selector, completionProvider, '"');
+		if (selector.language === "yaml") {
+			vscode.languages.registerCompletionItemProvider(selector, completionProvider, "'", '"');
+		} else {
+			vscode.languages.registerCompletionItemProvider(selector, completionProvider, '"');
+		}
   }
 
   const jsonSchemaDefinitionProvider = new JsonSchemaDefinitionProvider(cache, externalRefProvider);


### PR DESCRIPTION
Changes:
* Allow autocompletion for `$ref` when single quotes are used in `yaml` files.
* Fix minor spelling issue in `completion.ts`