### PR TITLE
Make tests executable again

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "build-webapps": "cd packages && npm run build",
     "compile": "tsc -b",
     "watch": "tsc -b -w",
-    "pretest": "npm run compile",
+    "pretest": "npm run build",
     "test": "node ./out/test/runTest.js"
   },
   "contributes": {
@@ -858,6 +858,7 @@
     "@vscode/test-electron": "^2.1.2",
     "glob": "^7.1.4",
     "marked": "^4.0.10",
+    "mocha": "^10.2.0",
     "typescript": "^5.0.2"
   }
 }


### PR DESCRIPTION
This fixes an issue that `npm test` cannot be successfully executed in a vanilla install of the repository.
This is due to
- the `mocha` dependency missing in the `package.json`
- test cases relying on build artifacts that will not be there using the previous life-cycle dependencies