### PR TITLE
Make actionEvent of extension more specific

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "redhat.vscode-yaml"
   ],
   "activationEvents": [
-    "*",
+    "onStartupFinished",
     "onFileSystem:openapi-42crunch"
   ],
   "capabilities": {


### PR DESCRIPTION
There is a warning in the `package.json` about the `activationEvent`: `Using '*' activation is usually a bad idea as it impacts performance.`

As explained [in the vscode docs](https://code.visualstudio.com/api/references/activation-events#Start-up), the `*` corresponds to 'always activate`.
This PR makes this actionEvent more specific. Ideally, the extension should only be activated for `json` and `yaml` files using [onLanguage](https://code.visualstudio.com/api/references/activation-events#Start-up):
```json
"activationEvents": [
    "onLanguage:yaml",
    "onLanguage:json"
]
```
However the `deleteYamlNode` test case is failing then. Maybe it would make sense that someone with more experience of this project (@ak1394 ?) could take a look in a second step to improve this further